### PR TITLE
openssl: bump to 1.0.2m

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_BASE:=1.0.2
-PKG_BUGFIX:=j
+PKG_BUGFIX:=m
 PKG_VERSION:=$(PKG_BASE)$(PKG_BUGFIX)
 PKG_RELEASE:=1
 PKG_USE_MIPS16:=0
@@ -22,7 +22,7 @@ PKG_SOURCE_URL:=http://www.openssl.org/source/ \
 	http://www.openssl.org/source/old/$(PKG_BASE)/ \
 	ftp://ftp.funet.fi/pub/crypt/mirrors/ftp.openssl.org/source \
 	ftp://ftp.sunet.se/pub/security/tools/net/openssl/source/
-PKG_MD5SUM:=96322138f0b69e61b7212bc53d5e912b
+PKG_MD5SUM:=10e9e37f492094b9ef296f68f24a7666
 
 PKG_LICENSE:=OpenSSL
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/110-optimize-for-size.patch
+++ b/package/libs/openssl/patches/110-optimize-for-size.patch
@@ -1,6 +1,6 @@
 --- a/Configure
 +++ b/Configure
-@@ -468,6 +468,12 @@ my %table=(
+@@ -470,6 +470,12 @@ my %table=(
  "linux-alpha-ccc","ccc:-fast -readonly_strings -DL_ENDIAN::-D_REENTRANT:::SIXTY_FOUR_BIT_LONG RC4_CHUNK DES_INT DES_PTR DES_RISC1 DES_UNROLL:${alpha_asm}",
  "linux-alpha+bwx-ccc","ccc:-fast -readonly_strings -DL_ENDIAN::-D_REENTRANT:::SIXTY_FOUR_BIT_LONG RC4_CHAR RC4_CHUNK DES_INT DES_PTR DES_RISC1 DES_UNROLL:${alpha_asm}",
  

--- a/package/libs/openssl/patches/150-no_engines.patch
+++ b/package/libs/openssl/patches/150-no_engines.patch
@@ -1,6 +1,6 @@
 --- a/Configure
 +++ b/Configure
-@@ -2114,6 +2114,11 @@ EOF
+@@ -2129,6 +2129,11 @@ EOF
  	close(OUT);
    }
    

--- a/package/libs/openssl/patches/160-disable_doc_tests.patch
+++ b/package/libs/openssl/patches/160-disable_doc_tests.patch
@@ -27,7 +27,7 @@
  WDIRS=  windows
  LIBS=   libcrypto.a libssl.a
  SHARED_CRYPTO=libcrypto$(SHLIB_EXT)
-@@ -275,7 +275,7 @@ reflect:
+@@ -276,7 +276,7 @@ reflect:
  
  sub_all: build_all
  
@@ -36,7 +36,7 @@
  
  build_libs: build_libcrypto build_libssl openssl.pc
  
-@@ -533,7 +533,7 @@ dist:
+@@ -542,7 +542,7 @@ dist:
  	@$(MAKE) SDIRS='$(SDIRS)' clean
  	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
  
@@ -47,7 +47,7 @@
  	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
 --- a/Makefile.org
 +++ b/Makefile.org
-@@ -531,7 +531,7 @@ dist:
+@@ -540,7 +540,7 @@ dist:
  	@$(MAKE) SDIRS='$(SDIRS)' clean
  	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
  

--- a/package/libs/openssl/patches/190-remove_timestamp_check.patch
+++ b/package/libs/openssl/patches/190-remove_timestamp_check.patch
@@ -9,7 +9,7 @@
  
  # as we stick to -e, CLEARENV ensures that local variables in lower
  # Makefiles remain local and variable. $${VAR+VAR} is tribute to Korn
-@@ -403,11 +403,6 @@ openssl.pc: Makefile
+@@ -404,11 +404,6 @@ openssl.pc: Makefile
  	    echo 'Version: '$(VERSION); \
  	    echo 'Requires: libssl libcrypto' ) > openssl.pc
  

--- a/package/libs/openssl/patches/200-parallel_build.patch
+++ b/package/libs/openssl/patches/200-parallel_build.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.org
 +++ b/Makefile.org
-@@ -281,17 +281,17 @@ build_libcrypto: build_crypto build_engi
+@@ -282,17 +282,17 @@ build_libcrypto: build_crypto build_engi
  build_libssl: build_ssl libssl.pc
  
  build_crypto:
@@ -24,7 +24,7 @@
  
  all_testapps: build_libs build_testapps
  build_testapps:
-@@ -464,7 +464,7 @@ update: errors stacks util/libeay.num ut
+@@ -473,7 +473,7 @@ update: errors stacks util/libeay.num ut
  	@set -e; target=update; $(RECURSIVE_BUILD_CMD)
  
  depend:
@@ -33,7 +33,7 @@
  
  lint:
  	@set -e; target=lint; $(RECURSIVE_BUILD_CMD)
-@@ -526,9 +526,9 @@ dist:
+@@ -535,9 +535,9 @@ dist:
  	@$(MAKE) SDIRS='$(SDIRS)' clean
  	@$(MAKE) TAR='$(TAR)' TARFLAGS='$(TARFLAGS)' $(DISTTARVARS) tar
  
@@ -45,7 +45,7 @@
  	@$(PERL) $(TOP)/util/mkdir-p.pl $(INSTALL_PREFIX)$(INSTALLTOP)/bin \
  		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR) \
  		$(INSTALL_PREFIX)$(INSTALLTOP)/$(LIBDIR)/engines \
-@@ -537,12 +537,19 @@ install_sw:
+@@ -546,12 +546,19 @@ install_sw:
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/misc \
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/certs \
  		$(INSTALL_PREFIX)$(OPENSSLDIR)/private
@@ -66,7 +66,7 @@
  	@set -e; liblist="$(LIBS)"; for i in $$liblist ;\
  	do \
  		if [ -f "$$i" ]; then \
-@@ -626,12 +633,7 @@ install_html_docs:
+@@ -635,12 +642,7 @@ install_html_docs:
  		done; \
  	done
  
@@ -173,7 +173,7 @@
  
  apps:
  	@(cd ..; $(MAKE) DIRS=apps all)
-@@ -577,7 +577,7 @@ $(DTLSTEST)$(EXE_EXT): $(DTLSTEST).o ssl
+@@ -578,7 +578,7 @@ $(DTLSTEST)$(EXE_EXT): $(DTLSTEST).o ssl
  #	fi
  
  dummytest$(EXE_EXT): dummytest.o $(DLIBCRYPTO)


### PR DESCRIPTION
Fixes:
CVE-2017-3731: Truncated packet could crash via OOB read
CVE-2017-3732: BN_mod_exp may produce incorrect results on x86_64
CVE-2016-7055: Montgomery multiplication may produce incorrect results
CVE-2017-3735: Malformed X.509 IPAddressFamily could cause OOB read
CVE-2017-3736: bn_sqrx8x_internal carry bug on x86_64

Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>